### PR TITLE
feat: make `@octokit/openapi-webhooks` ESM

### DIFF
--- a/packages/openapi-webhooks/index.js
+++ b/packages/openapi-webhooks/index.js
@@ -1,24 +1,25 @@
 export const schemas = {
-  ["api.github.com"]: await import("./generated/api.github.com.json", {
-    with: { type: "json" },
-  }),
-  ["ghec"]: await import("./generated/ghec.json", { with: { type: "json" } }),
-  ["ghes-3.10"]: await import("./generated/ghes-3.10.json", {
-    with: { type: "json" },
-  }),
-  ["ghes-3.11"]: await import("./generated/ghes-3.11.json", {
-    with: { type: "json" },
-  }),
-  ["ghes-3.12"]: await import("./generated/ghes-3.12.json", {
-    with: { type: "json" },
-  }),
-  ["ghes-3.13"]: await import("./generated/ghes-3.13.json", {
-    with: { type: "json" },
-  }),
-  ["ghes-3.14"]: await import("./generated/ghes-3.14.json", {
-    with: { type: "json" },
-  }),
-  ["ghes-3.15"]: await import("./generated/ghes-3.15.json", {
-    with: { type: "json" },
-  }),
+  ["api.github.com"]: (
+    await import("./generated/api.github.com.json", { with: { type: "json" } })
+  ).default,
+  ["ghec"]: (await import("./generated/ghec.json", { with: { type: "json" } }))
+    .default,
+  ["ghes-3.10"]: (
+    await import("./generated/ghes-3.10.json", { with: { type: "json" } })
+  ).default,
+  ["ghes-3.11"]: (
+    await import("./generated/ghes-3.11.json", { with: { type: "json" } })
+  ).default,
+  ["ghes-3.12"]: (
+    await import("./generated/ghes-3.12.json", { with: { type: "json" } })
+  ).default,
+  ["ghes-3.13"]: (
+    await import("./generated/ghes-3.13.json", { with: { type: "json" } })
+  ).default,
+  ["ghes-3.14"]: (
+    await import("./generated/ghes-3.14.json", { with: { type: "json" } })
+  ).default,
+  ["ghes-3.15"]: (
+    await import("./generated/ghes-3.15.json", { with: { type: "json" } })
+  ).default,
 };

--- a/packages/openapi-webhooks/index.js
+++ b/packages/openapi-webhooks/index.js
@@ -1,12 +1,24 @@
-module.exports = {
-  schemas: {
-    ["api.github.com"]: require("./generated/api.github.com.json"),
-    ["ghec"]: require("./generated/ghec.json"),
-    ["ghes-3.10"]: require("./generated/ghes-3.10.json"),
-    ["ghes-3.11"]: require("./generated/ghes-3.11.json"),
-    ["ghes-3.12"]: require("./generated/ghes-3.12.json"),
-    ["ghes-3.13"]: require("./generated/ghes-3.13.json"),
-    ["ghes-3.14"]: require("./generated/ghes-3.14.json"),
-    ["ghes-3.15"]: require("./generated/ghes-3.15.json"),
-  },
+export const schemas = {
+  ["api.github.com"]: await import("./generated/api.github.com.json", {
+    with: { type: "json" },
+  }),
+  ["ghec"]: await import("./generated/ghec.json", { with: { type: "json" } }),
+  ["ghes-3.10"]: await import("./generated/ghes-3.10.json", {
+    with: { type: "json" },
+  }),
+  ["ghes-3.11"]: await import("./generated/ghes-3.11.json", {
+    with: { type: "json" },
+  }),
+  ["ghes-3.12"]: await import("./generated/ghes-3.12.json", {
+    with: { type: "json" },
+  }),
+  ["ghes-3.13"]: await import("./generated/ghes-3.13.json", {
+    with: { type: "json" },
+  }),
+  ["ghes-3.14"]: await import("./generated/ghes-3.14.json", {
+    with: { type: "json" },
+  }),
+  ["ghes-3.15"]: await import("./generated/ghes-3.15.json", {
+    with: { type: "json" },
+  }),
 };

--- a/packages/openapi-webhooks/package.json
+++ b/packages/openapi-webhooks/package.json
@@ -7,7 +7,7 @@
     "generated/*",
     "index.js"
   ],
-  "type": "commonjs",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/octokit/openapi-webhooks.git",
@@ -24,5 +24,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "engines": {
+    "node": "^18.20.0 || >= 20.10.0"
   }
 }

--- a/packages/openapi-webhooks/types.d.ts
+++ b/packages/openapi-webhooks/types.d.ts
@@ -1,0 +1,10 @@
+export declare const schemas: {
+  "api.github.com": Record<string, unknown>;
+  ghec: Record<string, unknown>;
+  "ghes-3.10": Record<string, unknown>;
+  "ghes-3.11": Record<string, unknown>;
+  "ghes-3.12": Record<string, unknown>;
+  "ghes-3.13": Record<string, unknown>;
+  "ghes-3.14": Record<string, unknown>;
+  "ghes-3.15": Record<string, unknown>;
+};

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -134,7 +134,7 @@ async function run() {
     schemasCode += `["${name.replace(
       ".json",
       "",
-    )}"]: await import("./generated/${name}", { with: { type: "json" } }),`;
+    )}"]: (await import("./generated/${name}", { with: { type: "json" } })).default,`;
     schemasTypes += `"${name.replace(
       ".json",
       "",

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -1,5 +1,5 @@
-import { get } from "https";
-import fs from "fs";
+import { get } from "node:https";
+import fs from "node:fs";
 
 import { Octokit } from "@octokit/core";
 import { getCurrentVersions } from "github-enterprise-server-versions";

--- a/scripts/overrides/index.js
+++ b/scripts/overrides/index.js
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { resolve, join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SUPPORTED_GHES_OPERATIONS = [
   "3.10",


### PR DESCRIPTION
BREAKING CHANGE: The schema package is now ESM only
BREAKING CHANGE: Require Node v18.20+ or >= 20.10 due to import attributes

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves #106 

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Package was in CJS

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Package is now ESM

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

---
